### PR TITLE
Adding READMe for Faraday instrumentation

### DIFF
--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -30,6 +30,8 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+An example of how to interface with Faraday can be found within the example/faraday.rb directory.
+
 ## How can I get involved?
 
 The `opentelemetry-instrumentation-faraday` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -1,0 +1,49 @@
+# OpenTelemetry Faraday Instrumentation
+
+The OpenTelemetry Faraday Ruby gem is a community maintained instrumentation for [Faraday][faraday-home]. This is an HTTP client library that provides a common interface over many adaptors, such as Net::HTTP.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-faraday
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-faraday` in your `Gemfile`.
+
+## Usage
+
+To install the instrumentation, call `use` with the name of the instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Faraday'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-faraday` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[faraday-home]: https://github.com/lostisland/faraday
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -30,7 +30,7 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-An example of how to interface with Faraday can be found within the example/faraday.rb directory.
+An example of how to interface with Faraday can be found in `example/faraday.rb`.
 
 ## How can I get involved?
 

--- a/instrumentation/sidekiq/README.md
+++ b/instrumentation/sidekiq/README.md
@@ -1,0 +1,50 @@
+# OpenTelemetry Sidekiq Instrumentation
+
+The Sidekiq instrumentation is a community-maintained instrumentation for the [Sidekiq][sidekiq-home] Ruby jobs system.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-sidekiq
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-sidekiq` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Sidekiq'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## How can I get invovled?
+
+The `opentelemetry-instrumentation-sidekiq` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-sidekiq` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[sidekiq-home]: https://github.com/mperham/sidekiq
+[bundler-home]: https://bundler.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby


### PR DESCRIPTION
This PR adds documentation for OpenTelemetry's Faraday Instrumentation, closing #237. The README describes the Faraday gem, installation methods and its license, following the pattern set in instrumentation/sidekiq and instrumentation/concurrent_ruby for consistency.