### PR TITLE
Added README for Rack Documentation

### DIFF
--- a/instrumentation/rack/README.md
+++ b/instrumentation/rack/README.md
@@ -1,0 +1,50 @@
+# OpenTelemetry Rack Instrumentation
+
+The Rack instrumentation is a community-maintained instrumentation for the [Rack][rack-home] Ruby jobs system.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-rack
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-rack` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::rack'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## How can I get invovled?
+
+The `opentelemetry-instrumentation-rack` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-rack` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[rack-home]: https://github.com/mperham/rack
+[bundler-home]: https://bundler.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby


### PR DESCRIPTION
This PR adds documentation for OpenTelemetry-Ruby's Rack Instrumentation, which closes #[239](https://github.com/open-telemetry/opentelemetry-ruby/issues/239). The README describes the Rack gem, installation methods and its license, following the pattern set in instrumentation/sinatra for consistency.